### PR TITLE
List connected clients

### DIFF
--- a/lib/unifi.rb
+++ b/lib/unifi.rb
@@ -13,5 +13,6 @@ require 'unifi/login'
 require 'unifi/authorize_guest'
 require 'unifi/unauthorize_guest'
 require 'unifi/list_clients'
+require 'unifi/list_devices'
 
 #

--- a/lib/unifi.rb
+++ b/lib/unifi.rb
@@ -1,14 +1,18 @@
 require 'openssl'
+require 'json'
 require 'faraday'
 require 'faraday-cookie_jar'
+require 'faraday_middleware'
 require 'troupe'
 require 'addressable'
 require 'unifi/version'
 require 'unifi/controller'
+require 'unifi/get_from_controller'
 require 'unifi/post_to_controller'
 require 'unifi/login'
 require 'unifi/authorize_guest'
 require 'unifi/unauthorize_guest'
+require 'unifi/list_clients'
 
 module Unifi
   OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE

--- a/lib/unifi.rb
+++ b/lib/unifi.rb
@@ -14,6 +14,4 @@ require 'unifi/authorize_guest'
 require 'unifi/unauthorize_guest'
 require 'unifi/list_clients'
 
-module Unifi
-  OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
-end
+#

--- a/lib/unifi/controller.rb
+++ b/lib/unifi/controller.rb
@@ -10,7 +10,8 @@ module Unifi
         ssl: { verify: false }
       ) do |faraday|
         faraday.use      :cookie_jar
-        faraday.response :logger
+        # faraday.response :logger
+        faraday.response :json, content_type: /\bjson$/
         faraday.adapter  Faraday.default_adapter
       end
     end
@@ -34,6 +35,11 @@ module Unifi
     def unauthorize_guest(opts)
       interactor = Unifi::UnauthorizeGuest.call(opts.merge(site: site, conn: conn))
       interactor.response
+    end
+
+    def clients
+      interactor = Unifi::ListClients.call(site: site, conn: conn)
+      interactor.response.body["data"]
     end
 
     private

--- a/lib/unifi/controller.rb
+++ b/lib/unifi/controller.rb
@@ -42,6 +42,11 @@ module Unifi
       interactor.response.body["data"]
     end
 
+    def devices
+      interactor = Unifi::ListDevices.call(site: site, conn: conn)
+      interactor.response.body["data"]
+    end
+
     private
     attr_accessor :conn
   end

--- a/lib/unifi/get_from_controller.rb
+++ b/lib/unifi/get_from_controller.rb
@@ -1,17 +1,14 @@
 module Unifi
-  class PostToController
+  class GetFromController
     include Troupe
 
     expects :conn # Faraday connection from a Controller object
 
     provides :response
 
-    provides(:json) { {}.to_json }
-
     def call
-      self.response = conn.post do |req|
+      self.response = conn.get do |req|
         req.url url
-        req.body = json
       end
     end
   end

--- a/lib/unifi/list_clients.rb
+++ b/lib/unifi/list_clients.rb
@@ -1,0 +1,9 @@
+module Unifi
+  class ListClients < GetFromController
+    include Troupe
+
+    expects :site    # Controller site id
+
+    provides(:url) { "/api/s/#{site}/stat/sta" }
+  end
+end

--- a/lib/unifi/list_devices.rb
+++ b/lib/unifi/list_devices.rb
@@ -1,0 +1,9 @@
+module Unifi
+  class ListDevices < GetFromController
+    include Troupe
+
+    expects :site    # Controller site id
+
+    provides(:url) { "/api/s/#{site}/stat/device" }
+  end
+end

--- a/unifi.gemspec
+++ b/unifi.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
 
   spec.add_dependency "faraday", "~> 0.9.2"
+  spec.add_dependency "faraday_middleware", "~> 0.10"
   spec.add_dependency "troupe", "~> 0.1.0"
   spec.add_dependency "addressable", "~> 2.4.0"
   spec.add_dependency "faraday-cookie_jar", "~> 0.0.6"


### PR DESCRIPTION
New method for the `Unifi::Controller` to retrieve all the clients currently connected to the network.
